### PR TITLE
fix plugin name in the installation example

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Using [lazy.nvim](https://github.com/folke/lazy.nvim):
 
 ```lua
 {
-  "tsukimizake/prompt-in-buf-nvim",
+  "tsukimizake/prompt-in-buf.nvim",
   config = function()
     require('prompt-in-buf').setup({
       keymap = '<leader>p', -- Set a keymap to quickly open the prompt buffer


### PR DESCRIPTION
The plugin name in the installation example was `tsukimizake/prompt-in-buf-nvim` instead of the correct `tsukimizake/prompt-in-buf.nvim`, which caused the installation to fail, so I corrected it.